### PR TITLE
Add more checks to make-zip.sh

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,7 @@ indent_size = 2
 [*.xml]
 indent_style = space
 indent_size = 2
+
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Obtain the current development version of GameMode extension via:
 	git clone https://github.com/gicmo/gamemode-extension.git
 
 A script is included to create a zip archive which also can also install
-the extension for the current user.
+the extension for the current user. It depends on `meson`, `ninja` and `jq`.
 
 	./make-zip.sh         # just create the archive
 	./make-zip.sh install # create the archive and install it

--- a/make-zip.sh
+++ b/make-zip.sh
@@ -20,6 +20,11 @@ uuid=`(jq -r .uuid "$builddir/metadata.json")`
 name=`(jq -r '."extension-id"' "$builddir/metadata.json")`
 schema=`(jq -r '."settings-schema"' "$builddir/metadata.json")`
 
+if [ -z "$uuid" ];then
+    echo "Could not read UUID from metadata. Aborting." >&2
+    exit 1
+fi
+
 zipname="$uuid.shell-extension.zip"
 
 rm -f "$srcdir/$zipname"

--- a/make-zip.sh
+++ b/make-zip.sh
@@ -2,6 +2,13 @@
 set -e
 # Largely inspired by Florian Müllner gnome-shell-extensions/export-zips.sh
 
+for cmd in meson ninja jq; do
+    if ! [ -x "$(command -v ${cmd})" ]; then
+        echo "Need '${cmd}' command. Please install." >&2
+        exit 1
+    fi
+done
+
 builddir="build/"
 
 srcdir=`dirname $0`

--- a/make-zip.sh
+++ b/make-zip.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 # Largely inspired by Florian Müllner gnome-shell-extensions/export-zips.sh
 
 builddir="build/"


### PR DESCRIPTION
Currently make-zip.sh is fragile and might eat the whole extension dir if `jq` is not installed, because `uuid` will be empty. Fix this by adding more checks.
Closes #9 