### PR TITLE
extension: fix language display problem (zh_CN)

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,1 +1,1 @@
-de fr it
+de fr it zh_CN


### PR DESCRIPTION
In commit 10b8345e42b3de67576714d17ad54547e6a2dca7, zh_CN is not translated into machine language (.mo),
because I forgot to define the new language region in the LINGUAS list, which I fixed in this commit.