### PR TITLE
Fix typo about notification icon name

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -187,7 +187,7 @@ var GameModeIndicator = GObject.registerClass(
         _ensureSource() {
             if (!this._source) {
                 this._source = new MessageTray.Source('GameMode',
-                                                      'application-games-symbolic');
+                                                      'applications-games-symbolic');
                 this._source.connect('destroy', () => {
                     this._source = null;
                 });


### PR DESCRIPTION
Because of a minor typo, icon in notifications was broken. This fixes it.

Related issue [here](https://github.com/gicmo/gamemode-extension/issues/32)