### PR TITLE
Add support for gnome-shell 41 / GTK 4

### DIFF
--- a/metadata.json.in
+++ b/metadata.json.in
@@ -3,7 +3,7 @@
   "name": "GameMode",
   "description": "Status indicator for GameMode",
   "uuid": "@UUID@",
-  "shell-version": ["3.38", "40"],
+  "shell-version": ["3.38", "40", "41"],
   "version": "@VERSION@",
   "url": "@URL@",
   "original-author": "ckellner@redhat.com",

--- a/prefs.js
+++ b/prefs.js
@@ -25,6 +25,10 @@ var GameModeSettings = GObject.registerClass(class GameModePrefWidget extends Gt
             this.add(this.make_row_switch('always-show-icon'));
             this.add(this.make_row_switch('active-tint', 'active-color'));
         } else {
+            this.margin_start = 24;
+            this.margin_end = 24;
+            this.margin_top = 24;
+            this.margin_bottom = 24;
             this.append(this.make_row_switch('emit-notifications'));
             this.append(this.make_row_switch('always-show-icon'));
             this.append(this.make_row_switch('active-tint', 'active-color'));
@@ -43,7 +47,10 @@ var GameModeSettings = GObject.registerClass(class GameModePrefWidget extends Gt
         if (shellVersion < 40) {
             row.add(hbox);
         } else {
-            hbox.margin = 12;
+            hbox.margin_start = 12;
+            hbox.margin_end = 12;
+            hbox.margin_top = 12;
+            hbox.margin_bottom = 12;
             row.child = hbox;
         }
 
@@ -77,6 +84,8 @@ var GameModeSettings = GObject.registerClass(class GameModePrefWidget extends Gt
             if (shellVersion < 40) {
                 hbox.pack_start(button, false, false, 6);
             } else {
+                button.margin_start = 6;
+                button.margin_end = 6;
                 hbox.append(button);
             }
 


### PR DESCRIPTION
The only problem that seems to prevent the extension from working in Gnome 40 / 41 with GTK 4 is the use of the [`Gtk.Box.margin` property ](https://gjs-docs.gnome.org/gtk30/gtk.widget#property-margin) (inherited from `Gtk.Witdget `and removed in GTK 4).   The simplest solution is to fall back to the new [`margin-x`](https://gjs-docs.gnome.org/gtk40/gtk.widget#property-margin_bottom) properties. 

On the other hand, when replacing `pack_start` by `append ` we lose the `padding` argument, so the colour picker button appears stuck to the switch. Using `margin-start `and `margin-end` in the child widget is simple to emulate the above behaviour.

In principle this should fix the bug reported in Gnome 40 (GTK 4) and allow the extension to work seamlessly with gnome-shell 41.

I tested this changes on Gnome-Shell 41.1 (GTK 4.4.1, GJS 1.70.0). 

Fixes #45, fixes #44 