### PR TITLE
ci: replace ppc64le with arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 arch:
   - amd64
-  - ppc64le
+  - arm64
 
 language: node_js
 node_js:


### PR DESCRIPTION
Probably more widely used and ppc64le seems to not work.