### PR TITLE
Enable "Do Not Disturb" when active (#15)

### DIFF
--- a/data/settings.gschema.xml
+++ b/data/settings.gschema.xml
@@ -11,6 +11,11 @@
       <summary>Always show the icon</summary>
       <description>Display the icon even if GameMode is currently not active.</description>
     </key>
+    <key type="b" name="do-not-disturb">
+      <default>false</default>
+      <summary>Do Not Disturb</summary>
+      <description>Disable notification banners when GameMode is active.</description>
+    </key>
     <key type="b" name="active-tint">
       <default>false</default>
       <summary>Active icon tint</summary>

--- a/prefs.js
+++ b/prefs.js
@@ -23,6 +23,7 @@ var GameModeSettings = GObject.registerClass(class GameModePrefWidget extends Gt
             this.margin = 24;
             this.add(this.make_row_switch('emit-notifications'));
             this.add(this.make_row_switch('always-show-icon'));
+            this.add(this.make_row_switch('do-not-disturb'));
             this.add(this.make_row_switch('active-tint', 'active-color'));
         } else {
             this.margin_start = 24;
@@ -31,6 +32,7 @@ var GameModeSettings = GObject.registerClass(class GameModePrefWidget extends Gt
             this.margin_bottom = 24;
             this.append(this.make_row_switch('emit-notifications'));
             this.append(this.make_row_switch('always-show-icon'));
+            this.append(this.make_row_switch('do-not-disturb'));
             this.append(this.make_row_switch('active-tint', 'active-color'));
         }
     }

--- a/prefs.js
+++ b/prefs.js
@@ -291,6 +291,7 @@ function fillPreferencesWindow(window) {
     
     main_group.add(new SwitchActionRow({active_key: 'emit-notifications'}));
     main_group.add(new SwitchActionRow({active_key: 'always-show-icon'}));
+    main_group.add(new SwitchActionRow({active_key: 'do-not-disturb'}));
     main_group.add(new ColorActionRow(
         {active_key: 'active-tint', color_key: 'active-color'}));    
     


### PR DESCRIPTION
This PR adds the "Do Not Disturb" toggle functionality that was mentioned in #15. This is also my first time working on writing GNOME extensions so please let me know if this could be improved in any way.

A small bug that I'm not entirely sure how to fix is there seems to be an issue where the "GameMode is inactive" notification gets sent before "Do Not Disturb" is fully disabled, which leads to the notification not popping up (it still is in the notification area, though). I'd be happy to fix this if anyone has any ideas on how to wait for the setting change to take effect.

Thank you for the awesome extension!