### PR TITLE
Add support for gnome-shell 42 and Libadwaita

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -114,6 +114,6 @@
     "ngettext": false
   },
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2018
   }
 }

--- a/metadata.json.in
+++ b/metadata.json.in
@@ -3,7 +3,7 @@
   "name": "GameMode",
   "description": "Status indicator for GameMode",
   "uuid": "@UUID@",
-  "shell-version": ["3.38", "40", "41"],
+  "shell-version": ["3.38", "40", "41", "42"],
   "version": "@VERSION@",
   "url": "@URL@",
   "original-author": "ckellner@redhat.com",

--- a/prefs.js
+++ b/prefs.js
@@ -1,15 +1,14 @@
-const GObject = imports.gi.GObject;
-const Gtk = imports.gi.Gtk;
-const Gdk = imports.gi.Gdk;
-const Lang = imports.lang;
-const Gio = imports.gi.Gio;
-
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
 const Config = imports.misc.config;
 const [major] = Config.PACKAGE_VERSION.split('.');
 const shellVersion = Number.parseInt(major);
+
+const {Gdk, Gio, GObject, Gtk} = imports.gi;
+const Lang = imports.lang;
+const Adw = shellVersion >= 42 ? imports.gi.Adw : null;
+
 
 var GameModeSettings = GObject.registerClass(class GameModePrefWidget extends Gtk.ListBox {
 
@@ -148,10 +147,132 @@ var GameModeSettings = GObject.registerClass(class GameModePrefWidget extends Gt
     }
 });
 
+
+/*Gnome 42 - libadwaita implementation*/
+
+const RowColorButton = shellVersion < 42 ? null : GObject.registerClass(
+    {
+        GTypeName: 'RowColorButton',
+        Properties: {
+            'css-color': GObject.ParamSpec.string(
+                'css-color', 'css color',
+                'The currently selected color, as a valid css color spec.',
+                GObject.ParamFlags.READWRITE, ''
+            )
+        }
+    },
+    class RowColorButton extends Gtk.ColorButton {
+
+        constructor(params) {
+            super(params);
+            this.bind_property_full(
+                'css-color', this, 'rgba',
+                GObject.BindingFlags.SYNC_CREATE |
+                GObject.BindingFlags.BIDIRECTIONAL,
+                (_, target)=> {
+                    let rgba = new Gdk.RGBA();
+                    rgba.parse(target);
+                    return [true, rgba];
+                },
+                (_, target)=>[true, target.to_string()]
+            );
+        }
+    });
+
+
+const SwitchActionRow = shellVersion < 42 ? null : GObject.registerClass(
+    {
+        GTypeName: 'SwitchActionRow',
+        Properties: {
+            'active-key': GObject.ParamSpec.string(
+                'active-key', 'Active key',
+                'Key name in settings that stores the switch active property.',
+                GObject.ParamFlags.READWRITE, ''
+            ),
+        },
+    },
+    class SwitchActionRow extends Adw.ActionRow {
+
+        constructor({active_key, ...args}) {  
+            super(args);
+            this._settings = ExtensionUtils.getSettings();
+            this._suffix_container = new Gtk.Box(
+                {orientation: Gtk.Orientation.HORIZONTAL}
+            );
+            this._switch = new Gtk.Switch({valign: Gtk.Align.CENTER});
+            
+            this.add_suffix(this._suffix_container);
+            this.add_suffix(this._switch);
+            this.set_activatable_widget(this._switch);
+            this.activeKey = active_key;
+        }
+
+        get active_key() {
+            return this._active_key;
+        }
+
+        set active_key(key) {
+            if (this.active_key === key)
+                return;
+            if (this._settings.settings_schema.get_key(key)) {
+                let schema_key = this._settings.settings_schema.get_key(key);
+                this.title = schema_key.get_summary();
+                this.subtitle = schema_key.get_description();
+                this._settings.bind(key, this._switch, 'active',
+                                    Gio.SettingsBindFlags.DEFAULT);
+                this._active_key = key;
+                this.notify('active-key');
+            }
+        }
+    });
+
+
+const ColorActionRow = shellVersion < 42 ? null : GObject.registerClass(
+    {
+        GTypeName: 'ColorActionRow',
+        InternalChilds: ['color_btn'],
+        Properties: {
+            'color-key': GObject.ParamSpec.string(
+                'color-key', 'Color key',
+                'Key name in settings that stores the selected color.',
+                GObject.ParamFlags.READWRITE, ''
+            ),
+        },
+    },
+    class ColorActionRow extends SwitchActionRow {
+    
+        constructor({color_key, ...args}) {  
+            super(args);
+            this._color_btn = new RowColorButton({valign: Gtk.Align.CENTER});
+            this._suffix_container.append(this._color_btn);
+            this.colorKey = color_key;
+        }
+        
+        get color_key() {
+            return this._color_key;
+        }
+
+        set color_key(key) {
+            if (this.color_key === key)
+                return;
+            if (this._settings.settings_schema.get_key(key)) {
+                let schema_key = this._settings.settings_schema.get_key(key);
+                this._color_btn.set_tooltip_markup(schema_key.get_description());
+                this._settings.bind(key, this._color_btn, 'css-color',
+                                    Gio.SettingsBindFlags.DEFAULT | 
+                                    Gio.SettingsBindFlags.NO_SENSITIVITY);
+                this._color_key = key;
+                this.notify('color-key');
+            }
+        }
+    });
+
+
 function init() {
     ExtensionUtils.initTranslations();
 }
 
+// Gnome Shell < 42
 function buildPrefsWidget() {
     let widget = new GameModeSettings();
 
@@ -161,3 +282,18 @@ function buildPrefsWidget() {
 
     return widget;
 }
+
+// Gnome Shell >= 42
+function fillPreferencesWindow(window) {
+    let settings_page = Adw.PreferencesPage.new();
+    let main_group = Adw.PreferencesGroup.new();
+    
+    main_group.add(new SwitchActionRow({active_key: 'emit-notifications'}));
+    main_group.add(new SwitchActionRow({active_key: 'always-show-icon'}));
+    main_group.add(new ColorActionRow(
+        {active_key: 'active-tint', color_key: 'active-color'}));    
+    
+    settings_page.add(main_group);
+    window.add(settings_page);
+}
+

--- a/prefs.js
+++ b/prefs.js
@@ -6,7 +6,6 @@ const [major] = Config.PACKAGE_VERSION.split('.');
 const shellVersion = Number.parseInt(major);
 
 const {Gdk, Gio, GObject, Gtk} = imports.gi;
-const Lang = imports.lang;
 const Adw = shellVersion >= 42 ? imports.gi.Adw : null;
 
 


### PR DESCRIPTION
This PR should provide support for Gnome 42, while implementing the use of Libadwaita widgets for this version and maintaining backwards compatibility with previous versions. I've tested it on Gnome 41 and 42 and there don't seem to be any problems.

Some notes:


- The change would only affect the preferences window .

- I've been hesitating quite a bit about how to implement it, in the end I've simply opted to isolate both implementations, leaving the pre-42 code intact (So all the previous _prefs.js_ code, minus the necessary imports, could be removed and the extension would work without problems in Gnome 42).
 This results in some more code, but no more conditionals added to the previous code, which I think can be confusing (especially when using different widgets in the new version). This also makes it easier to maintain. However, there are more ways to implement this, it is not necessarily the best one.

- The current implementation is quite simple, I use three classes that, basically, the main thing they do is allow the definition of two properties to bind the widgets with their respective GSettings keys. In addition, the `fillPreferencesWindow` function is added, which in Gnome 42 takes precedence over `buildPrefsWidget`, allowing backwards compatibility.

- I just realized that EsLint is angry with me because I use spread syntax (`...`) in class constructors :( It could be resolved by moving from 2017 ECMA version (which now uses the linter) to 2018, but I don't know if this can be a problem...

Just as a note, originally it used composite templates (.ui files) but since the extension doesn't make use of them and the interface is relatively simple, I've dropped it. However, the window can be fully defined in a .ui file if desired, including assigning its respective key in GSettings. I don't think it has much importance, but if it turns out to be convenient in the future, the possibility exists.

Resolves #52, resolves #53