### PR TITLE
Add Gnome Shell 43 compatibility

### DIFF
--- a/metadata.json.in
+++ b/metadata.json.in
@@ -3,7 +3,7 @@
   "name": "GameMode",
   "description": "Status indicator for GameMode",
   "uuid": "@UUID@",
-  "shell-version": ["3.38", "40", "41", "42"],
+  "shell-version": ["3.38", "40", "41", "42", "43"],
   "version": "@VERSION@",
   "url": "@URL@",
   "original-author": "ckellner@redhat.com",


### PR DESCRIPTION
This requires no code changes to work.
However there is a new approach for Signals that can be used, but it will drop compatibility on Gnome Shell < 43
For more info on this: https://gjs.guide/extensions/upgrading/gnome-shell-43.html