### PR TITLE
ci: use Ubuntu 22.04 (Jammy Jellyfish)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: jammy
 arch:
   - amd64
   - arm64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: jammy
 arch:
   - amd64
-  - arm64
 
 language: node_js
 node_js:


### PR DESCRIPTION
Need newer distro for npm to work otherwise:
```
  node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by node)
```